### PR TITLE
[codex] Improve navigation cleanup and document safeguards

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:16-alpine

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -40,7 +41,7 @@ export default function LoginPage() {
     <div className="login-page">
       <div className="login-card">
         <div className="login-logo">
-          <img src="/logo-principal.jpg" alt="Coopeenortol" />
+          <Image src="/logo-principal.jpg" alt="Coopeenortol" width={180} height={96} priority />
           <h1>Coopeenortol</h1>
           <p>Sistema de Gestión de Cooperativa</p>
         </div>

--- a/src/app/(dashboard)/aportes/page.tsx
+++ b/src/app/(dashboard)/aportes/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Search, Plus, DollarSign, Calendar, Filter, Eye, Ban } from 'lucide-react';
+import { Search, Plus, DollarSign, Calendar, Filter, Ban } from 'lucide-react';
 
 interface ContributionRow {
   id: string;

--- a/src/app/(dashboard)/asociados/[id]/page.tsx
+++ b/src/app/(dashboard)/asociados/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, use } from 'react';
 import { useRouter } from 'next/navigation';
-import { Save, ArrowLeft, Edit, History, UserCheck, UserX, AlertCircle, Plus, Trash2, User, MapPin, Briefcase, Heart, Clock, Wallet, Landmark, DollarSign, TrendingUp, FileText, Upload, Download } from 'lucide-react';
+import { Save, ArrowLeft, Edit, UserCheck, AlertCircle, Plus, Trash2, User, MapPin, Briefcase, Heart, Clock, Wallet, Landmark, DollarSign, TrendingUp, FileText, Upload, Download } from 'lucide-react';
 
 interface PersonData {
   id: string;
@@ -126,7 +126,6 @@ export default function AsociadoDetallePage({ params }: { params: Promise<{ id: 
   const [documentTypes, setDocumentTypes] = useState<CatalogItem[]>([]);
   const [genders, setGenders] = useState<CatalogItem[]>([]);
   const [maritalStatuses, setMaritalStatuses] = useState<CatalogItem[]>([]);
-  const [relationships, setRelationships] = useState<CatalogItem[]>([]);
   const [housingTypes, setHousingTypes] = useState<CatalogItem[]>([]);
 
   // Formulario editable
@@ -256,7 +255,6 @@ export default function AsociadoDetallePage({ params }: { params: Promise<{ id: 
               case 'TIPO_DOCUMENTO': setDocumentTypes(items); break;
               case 'GENERO': setGenders(items); break;
               case 'ESTADO_CIVIL': setMaritalStatuses(items); break;
-              case 'PARENTESCO': setRelationships(items); break;
               case 'TIPO_VIVIENDA': setHousingTypes(items); break;
             }
           }

--- a/src/app/(dashboard)/asociados/page.tsx
+++ b/src/app/(dashboard)/asociados/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Search, Plus, Eye, UserCheck, UserX, Clock, Filter } from 'lucide-react';
+import { Search, Plus, Eye, Filter } from 'lucide-react';
 
 interface AssociateRow {
   id: string;

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@
 import { useSession, signOut } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import Image from 'next/image';
 import {
   LayoutDashboard,
   Users,
@@ -21,9 +22,11 @@ import {
   Landmark,
   FileSpreadsheet,
   PieChart,
+  Receipt,
 } from 'lucide-react';
 import { useState } from 'react';
 import { SessionProvider } from 'next-auth/react';
+import { NAV_ITEMS } from '@/lib/constants';
 
 const iconMap: Record<string, React.ElementType> = {
   LayoutDashboard,
@@ -38,6 +41,7 @@ const iconMap: Record<string, React.ElementType> = {
   Landmark,
   FileSpreadsheet,
   PieChart,
+  Receipt,
 };
 
 interface NavItemConfig {
@@ -48,22 +52,7 @@ interface NavItemConfig {
   children?: { label: string; href: string; permission: string }[];
 }
 
-const navItems: NavItemConfig[] = [
-  { label: 'Dashboard', href: '/dashboard', icon: 'LayoutDashboard', permission: 'dashboard.view' },
-  { label: 'Usuarios', href: '/usuarios', icon: 'Users', permission: 'users.view' },
-  { label: 'Roles y Permisos', href: '/roles', icon: 'Shield', permission: 'roles.view' },
-  {
-    label: 'Parametrización',
-    href: '/parametrizacion',
-    icon: 'Settings',
-    permission: 'params.view',
-    children: [
-      { label: 'Catálogos', href: '/parametrizacion/catalogos', permission: 'params.view' },
-      { label: 'Configuración', href: '/parametrizacion/configuracion', permission: 'system.config' },
-    ],
-  },
-  { label: 'Auditoría', href: '/auditoria', icon: 'FileSearch', permission: 'audit.view' },
-];
+const navItems = NAV_ITEMS as NavItemConfig[];
 
 function SidebarNav({ permissions }: { permissions: string[] }) {
   const pathname = usePathname();
@@ -178,7 +167,7 @@ function DashboardLayoutInner({ children }: { children: React.ReactNode }) {
       {/* Sidebar */}
       <aside className={`sidebar ${sidebarOpen ? 'open' : ''}`}>
         <div className="sidebar-brand">
-          <img src="/logo-secundario.jpg" alt="Coopeenortol" />
+          <Image src="/logo-secundario.jpg" alt="Coopeenortol" width={44} height={44} />
           <div className="sidebar-brand-text">
             <h2>Coopeenortol</h2>
             <span>Sistema de Gestión</span>

--- a/src/app/api/asociados/[id]/beneficiarios/route.ts
+++ b/src/app/api/asociados/[id]/beneficiarios/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from 'next/server';
 import { addBeneficiary, removeBeneficiary } from '@/lib/services/associate.service';
 import { beneficiarySchema } from '@/lib/validations/schemas';
-import { successResponse, handleApiError, requirePermission } from '@/lib/api-helpers';
+import { successResponse, errorResponse, handleApiError, requirePermission } from '@/lib/api-helpers';
 import prisma from '@/lib/prisma';
 
 export async function GET(
@@ -45,7 +45,6 @@ export async function POST(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const user = await requirePermission('associates.edit');
@@ -53,7 +52,7 @@ export async function DELETE(
     const beneficiaryId = searchParams.get('beneficiaryId');
 
     if (!beneficiaryId) {
-      return successResponse({ error: 'Se requiere beneficiaryId' }, 400);
+      return errorResponse('Se requiere beneficiaryId', 400);
     }
 
     await removeBeneficiary(beneficiaryId, user.id);

--- a/src/app/api/asociados/[id]/documentos/[docId]/route.ts
+++ b/src/app/api/asociados/[id]/documentos/[docId]/route.ts
@@ -13,9 +13,9 @@ export async function GET(
 ) {
   try {
     await requirePermission('associates.view');
-    const { docId } = await params;
+    const { id, docId } = await params;
 
-    const { buffer, fileName, mimeType } = await downloadDocument(docId);
+    const { buffer, fileName, mimeType } = await downloadDocument(docId, id);
 
     return new NextResponse(new Uint8Array(buffer), {
       headers: {
@@ -36,8 +36,8 @@ export async function DELETE(
 ) {
   try {
     const user = await requirePermission('associates.edit');
-    const { docId } = await params;
-    await deleteDocument(docId, user.id);
+    const { id, docId } = await params;
+    await deleteDocument(docId, id, user.id);
     return successResponse({ deleted: true });
   } catch (error) {
     return handleApiError(error);

--- a/src/app/api/asociados/[id]/documentos/route.ts
+++ b/src/app/api/asociados/[id]/documentos/route.ts
@@ -4,7 +4,7 @@
 
 import { NextRequest } from 'next/server';
 import { getDocumentsByAssociate, uploadDocument } from '@/lib/services/document.service';
-import { successResponse, handleApiError, requirePermission } from '@/lib/api-helpers';
+import { successResponse, errorResponse, handleApiError, requirePermission } from '@/lib/api-helpers';
 
 // GET: Listar documentos del asociado
 export async function GET(
@@ -35,15 +35,14 @@ export async function POST(
     const documentType = formData.get('documentType') as string | null;
 
     if (!file) {
-      return successResponse(null, 400);
+      return errorResponse('El archivo es requerido', 400);
     }
     if (!documentType) {
-      return successResponse(null, 400);
+      return errorResponse('El tipo de documento es requerido', 400);
     }
 
     // Validar tamaño (max 10MB)
     if (file.size > 10 * 1024 * 1024) {
-      const { errorResponse } = await import('@/lib/api-helpers');
       return errorResponse('El archivo no debe superar 10MB', 400);
     }
 
@@ -57,7 +56,6 @@ export async function POST(
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     ];
     if (!allowedTypes.includes(file.type)) {
-      const { errorResponse } = await import('@/lib/api-helpers');
       return errorResponse('Tipo de archivo no permitido. Use PDF, imágenes, Word o Excel.', 400);
     }
 

--- a/src/app/api/asociados/route.ts
+++ b/src/app/api/asociados/route.ts
@@ -9,7 +9,7 @@ import { successResponse, handleApiError, requirePermission } from '@/lib/api-he
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await requirePermission('associates.view');
+    await requirePermission('associates.view');
     const { searchParams } = new URL(request.url);
 
     const data = await getAssociates({

--- a/src/app/api/parametrizacion/config/route.ts
+++ b/src/app/api/parametrizacion/config/route.ts
@@ -10,8 +10,8 @@ export async function GET(request: NextRequest) {
   try {
     await requirePermission('system.config');
     const { searchParams } = new URL(request.url);
-    const module = searchParams.get('module') || undefined;
-    const configs = await getSystemConfigs(module);
+    const moduleFilter = searchParams.get('module') || undefined;
+    const configs = await getSystemConfigs(moduleFilter);
     return successResponse(configs);
   } catch (error) {
     return handleApiError(error);

--- a/src/app/api/recaudos/route.ts
+++ b/src/app/api/recaudos/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from 'next/server';
 import { getReceipts } from '@/lib/services/receipt.service';
 import { createBatchContributions } from '@/lib/services/contribution.service';
 import { createBatchContributionSchema } from '@/lib/validations/schemas';
-import { successResponse, handleApiError, requirePermission, validationErrorResponse } from '@/lib/api-helpers';
+import { successResponse, handleApiError, requirePermission, validationError } from '@/lib/api-helpers';
 import { AUDIT_ACTIONS, MODULES } from '@/lib/constants';
 import { createAuditLog } from '@/lib/services/audit.service';
 
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
 
     const parsed = createBatchContributionSchema.safeParse(body);
-    if (!parsed.success) return validationErrorResponse(parsed.error);
+    if (!parsed.success) return validationError(parsed.error);
 
     const { contributions, paymentMethod, reference, observations } = parsed.data;
 

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -3,7 +3,7 @@
 // ============================================================
 
 import { NextRequest } from 'next/server';
-import { getRoles, createRole, getAllPermissions } from '@/lib/services/role.service';
+import { getRoles, createRole } from '@/lib/services/role.service';
 import { createRoleSchema } from '@/lib/validations/schemas';
 import { successResponse, handleApiError, requirePermission } from '@/lib/api-helpers';
 

--- a/src/app/api/usuarios/[id]/route.ts
+++ b/src/app/api/usuarios/[id]/route.ts
@@ -17,7 +17,8 @@ export async function GET(
     const user = await getUserById(id);
     if (!user) return successResponse(null);
     
-    const { passwordHash: _, ...safeUser } = user;
+    const { passwordHash: _passwordHash, ...safeUser } = user;
+    void _passwordHash;
     return successResponse(safeUser);
   } catch (error) {
     return handleApiError(error);

--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -9,7 +9,7 @@ import { successResponse, handleApiError, requirePermission } from '@/lib/api-he
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await requirePermission('users.view');
+    await requirePermission('users.view');
     const { searchParams } = new URL(request.url);
 
     const data = await getUsers({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -171,6 +171,7 @@ img {
 
 .login-logo img {
   height: 70px;
+  width: auto;
   object-fit: contain;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
+    <html lang="es" data-scroll-behavior="smooth">
       <body>{children}</body>
     </html>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,6 +17,7 @@ declare module 'next-auth' {
       lastName: string;
       roles: string[];
       permissions: string[];
+      emailVerified: Date | null;
     };
   }
   interface User {
@@ -104,7 +105,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return token;
     },
     async session({ session, token }) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       session.user = {
         id: token.id as string,
         email: token.email as string,
@@ -113,7 +113,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         roles: token.roles as string[],
         permissions: token.permissions as string[],
         emailVerified: null,
-      } as any;
+      };
       return session;
     },
   },

--- a/src/lib/services/document.service.ts
+++ b/src/lib/services/document.service.ts
@@ -72,9 +72,9 @@ export async function uploadDocument(
 // ------------------------------------------------------------
 // Descargar un documento
 // ------------------------------------------------------------
-export async function downloadDocument(documentId: string) {
-  const doc = await prisma.associateDocument.findUnique({
-    where: { id: documentId },
+export async function downloadDocument(documentId: string, associateId: string) {
+  const doc = await prisma.associateDocument.findFirst({
+    where: { id: documentId, associateId },
   });
   if (!doc) throw new Error('Documento no encontrado');
 
@@ -91,9 +91,9 @@ export async function downloadDocument(documentId: string) {
 // ------------------------------------------------------------
 // Eliminar un documento
 // ------------------------------------------------------------
-export async function deleteDocument(documentId: string, performedBy: string) {
-  const doc = await prisma.associateDocument.findUnique({
-    where: { id: documentId },
+export async function deleteDocument(documentId: string, associateId: string, performedBy: string) {
+  const doc = await prisma.associateDocument.findFirst({
+    where: { id: documentId, associateId },
   });
   if (!doc) throw new Error('Documento no encontrado');
 

--- a/src/lib/storage/local.provider.ts
+++ b/src/lib/storage/local.provider.ts
@@ -10,7 +10,7 @@ import type { StorageProvider } from './index';
 const UPLOAD_BASE = path.join(process.cwd(), 'uploads', 'documents');
 
 export class LocalStorageProvider implements StorageProvider {
-  async upload(file: Buffer, filePath: string, _mimeType: string): Promise<string> {
+  async upload(file: Buffer, filePath: string): Promise<string> {
     const fullPath = path.join(UPLOAD_BASE, filePath);
     const dir = path.dirname(fullPath);
     await fs.mkdir(dir, { recursive: true });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
 // ============================================================
-// CoopManager - Auth Middleware
+// CoopManager - Auth Proxy
 // ============================================================
 
 import { NextResponse } from 'next/server';
@@ -9,7 +9,7 @@ import { auth } from '@/lib/auth';
 // Routes that don't require authentication
 const publicPaths = ['/login', '/api/auth'];
 
-export default async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Allow public paths

--- a/tests/e2e-test.mjs
+++ b/tests/e2e-test.mjs
@@ -54,7 +54,7 @@ async function runTests() {
   // 1. LOGIN
   // ========================================
   console.log('📋 1. LOGIN');
-  const loginRes = await req('POST', '/api/auth/callback/credentials', {
+  await req('POST', '/api/auth/callback/credentials', {
     email: 'admin@coopeenortol.com',
     password: 'Admin123!',
     csrfToken: '',
@@ -388,7 +388,6 @@ async function runTests() {
   console.log('\n📋 11. PARAMETRIZACIÓN');
   const catalogsRes = await req('GET', '/api/parametrizacion/catalogos');
   assert(catalogsRes.data?.success === true, 'Catálogos del sistema accesibles');
-  const catalogs = catalogsRes.data?.data?.data || [];
   const catalogsTotal = catalogsRes.data?.data?.total || 0;
   assert(catalogsTotal >= 11, `${catalogsTotal} catálogos del sistema`);
 


### PR DESCRIPTION
## Summary

- Connect the dashboard sidebar to the shared navigation configuration so all implemented modules appear consistently.
- Migrate Next.js middleware to the Next 16 proxy convention and clean lint/build warnings.
- Harden associate document download/delete APIs by scoping document access to the route associate id.
- Normalize invalid API responses and remove the obsolete Docker Compose `version` field.

## Validation

- `npm.cmd run lint`
- `npm.cmd run build`
- `node tests\e2e-test.mjs`
- `docker compose config`

## Notes

The GitHub CLI is not installed locally, so the branch was pushed with `git` and this draft PR was opened through the GitHub connector.